### PR TITLE
Add `bison`, `flex`, `libssl-dev` to the list of installed packages.

### DIFF
--- a/tasks/harden-raspbian-kernel.yml
+++ b/tasks/harden-raspbian-kernel.yml
@@ -11,6 +11,9 @@
     - git
     - bc
     - python-pexpect # For kernel configuration questions.
+    - bison
+    - flex
+    - libssl-dev
 
 - name: Ensure local source directory exists.
   file:


### PR DESCRIPTION
The latest Raspian builds require that these three packages be installed, _even if you're not cross-compiling_. Once these are installed, the kernel tasks run fine. :)